### PR TITLE
Update pw_exec.py

### DIFF
--- a/tools/pw_exec.py
+++ b/tools/pw_exec.py
@@ -25,6 +25,12 @@ import shutil
 import random
 import string
 
+#get msfvenom path
+f = open("../config/config.path","r")
+lines = f.readlines()
+msfvenom = lines[6]
+f.close()
+
 #
 # generate a random string
 #


### PR DESCRIPTION
pw_exec.py must be edited because if user uses metasploit from git and it is not in system path then the script will not be able to generate the payload because it will not find msfvenom .
I declared on line 28 msfvenom as a variable when i inserted the code to read config.path file to get msfvenom location .

However , in line 390 that code must be adjusted to new settings on msfvenom .
I was not able to figure out how to do it , i do not have knowledge in python scripting , but i am mentioning this so you can make the adjustments to that line 390 , since you already changed the script a few days ago , then you surely have more knowledge than me in python .

note : this lapse was forgot from the beginning of changes , i only notice it when you changed the code lately and i saw a call to msfvenom .
However if user have msfvenom in system path then there not should have any issue , but if user have msfvenom in a non system path then a python script error will popup when script is launched because python script is unable to find msfvenom manual installation directory .