### PR TITLE
Fudwin correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## CHANGELOG
 
+* v1.9.5 - Code missing in fudwin (fixed)
 * v1.9.5 - added dll injection attack 
 * v1.9.5 - update function () creator script into ver 1.3
 * v1.9.4 - Fix in microsploit option 5 , grab script created to get msfconsole generated payload while running

--- a/fatrat
+++ b/fatrat
@@ -1274,12 +1274,16 @@ echo "file in ($path/output/) with the name $fira.exe ."
 echo -e $okegreen ""
 echo " [✔] FatRat have renamed your old FUD Rat to old_$ren.exe"
 echo ""
+echo -e $cyan "[*] You can find your file in :
+$path/output/old_$ren.exe"
+else
 mv $fstager $path/output/$fira.exe >> $logfud 2>&1
 echo ""
 echo -e $cyan "[*] You can find your file in :
 $chk"
 echo ""
 fi
+
 #Option to create a listener
 echo ""
 echo -e $okegreen "Do you want to create a listener for this configuration"


### PR DESCRIPTION
simple Fudwin correction .
In case file with same name does not exists in final folder then fatrat would not copy the generated rat to output folder .
Fixed .