### PR TITLE
Fix wrong sed's that leads to incorrect configuration check.

### DIFF
--- a/fatrat
+++ b/fatrat
@@ -1073,16 +1073,16 @@ clear
 if [ -f "$file" ]
 then
 #config file exists , then load tools paths to specific variables
-msfconsole=`sed -n 13p $file`
-msfvenom=`sed -n 14p $file`
-backdoor=`sed -n 15p $file`
-searchsploit=`sed -n 16p $file`
-aapt=`sed -n 10p $file`
-apktool=`sed -n 11p $file`
+msfconsole=`sed -n 14p $file`
+msfvenom=`sed -n 15p $file`
+backdoor=`sed -n 16p $file`
+searchsploit=`sed -n 17p $file`
+aapt=`sed -n 11p $file`
+apktool=`sed -n 12p $file`
 keytool=`sed -n 7p $file`
 sign=`sed -n 5p $file`
-dx=`sed -n 9p $file`
-baksmali=`sed -n 12p $file`
+dx=`sed -n 10p $file`
+baksmali=`sed -n 13p $file`
 else
 #config file does not exist
 	echo -e $red"Configuration file does not exists , run setup.sh first for config ."


### PR DESCRIPTION
Currently when the setup is created it's:

```
********************************************************************************************************
** Configuration Paths for TheFatRat , do not delete anything from this file or program will not work **
**       if you need to reconfig your tools path , then run ./setup.sh in (TheFatRat directory) .     **
********************************************************************************************************
jarsigner
unzip
keytool
/usr/share/thefatrat/tools/android-sdk/zipalign
/usr/share/thefatrat/tools/proguard5.3.2/lib/proguard
dx
/opt/android-sdk/build-tools/*/aapt
apktool
d2j-dex2jar
msfconsole
msfvenom
backdoor-factory
searchsploit
```
And the sed's in the `fatrat` script uses that file to check if some tool exists or not. If you look for example at https://github.com/Screetsec/TheFatRat/blob/604e1cf08c8630f6b71e3221fd8f12c360acc3dc/fatrat#L1076 it's supposed to be `msfconsole` but if you executes that command the output is: 
```bash
└─ ▶ sed -n 13p /usr/share/thefatrat/config/config.path
d2j-dex2jar
```
And same error happens for more options. Doing the right sed's the tool works.